### PR TITLE
Update .gitignore to include some files generated during compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 hiro/qt/qt.moc
+libco/libco.o
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 hiro/qt/qt.moc
-libco/libco.o
 
 # Shared objects (inc. Windows DLLs)
 *.dll

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ hiro/qt/qt.moc
 # Shared objects (inc. Windows DLLs)
 *.dll
 *.so
-*.so.*
+*.o
 *.dylib


### PR DESCRIPTION
As indicated in the title, this small PR updates the .gitignore file in order to also include:

- one untracked file that is generated when compiling this core through MSYS2/Mingw64 on Windows (libco/libco.o);
- the respective library filetypes (.dll, .so, .dylib, etc.)