### PR TITLE
Allow Haiku build again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,11 @@ ifeq ($(platform), unix)
       IS_X86 = 1
    endif
    ifneq ($(findstring Haiku,$(shell uname -s)),)
+   SHARED += -Wl,-export-dynamic
    CXXFLAGS += -fpermissive
-   endif
+   else
    LDFLAGS += -ldl
+   endif
 else ifeq ($(platform), osx)
    TARGET := $(TARGET_NAME)_libretro.dylib
    fpic := -fPIC

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -32,6 +32,8 @@ ifeq ($(platform),)
     platform := linux
   else ifneq ($(findstring BSD,$(uname)),)
     platform := bsd
+  else ifneq ($(findstring Haiku,$(uname)),)
+    platform := haiku
   else
     $(error unknown platform, please specify manually.)
   endif

--- a/nall/directory.hpp
+++ b/nall/directory.hpp
@@ -267,6 +267,11 @@ inline auto directory::copy(const string& source, const string& target) -> bool 
   }
 #else
   inline auto directoryIsFolder(DIR* dp, struct dirent* ep) -> bool {
+#if defined(PLATFORM_HAIKU)
+    struct stat sp = {0};
+    fstatat(dirfd(dp), ep->d_name, &sp, 0);
+    return S_ISDIR(sp.st_mode);
+#else
     if(ep->d_type == DT_DIR) return true;
     if(ep->d_type == DT_LNK || ep->d_type == DT_UNKNOWN) {
       //symbolic links must be resolved to determine type
@@ -275,6 +280,7 @@ inline auto directory::copy(const string& source, const string& target) -> bool 
       return S_ISDIR(sp.st_mode);
     }
     return false;
+#endif
   }
 
   inline auto directory::create(const string& pathname, uint permissions) -> bool {

--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -4,7 +4,7 @@ namespace nall {
   using uint = unsigned;
 
   enum class Compiler : uint { Clang, GCC, Microsoft, Unknown };
-  enum class Platform : uint { Windows, MacOS, Linux, BSD, Android, Horizon, Unknown };
+  enum class Platform : uint { Windows, MacOS, Linux, BSD, BeAPI, Android, Horizon, Unknown };
   enum class API : uint { Windows, Posix, Unknown };
   enum class DisplayServer : uint { Windows, Quartz, Xorg, Unknown };
   enum class Architecture : uint { x86, amd64, ARM32, ARM64, PPC32, PPC64, Unknown };
@@ -112,6 +112,13 @@ namespace nall {
   constexpr auto platform() -> Platform { return Platform::BSD; }
   constexpr auto api() -> API { return API::Posix; }
   constexpr auto display() -> DisplayServer { return DisplayServer::Xorg; }
+ #elif defined(__HAIKU__)
+  #define PLATFORM_HAIKU
+  #define API_POSIX
+  #define DISPLAY_UNKNOWN
+  constexpr auto platform() -> Platform { return Platform::BeAPI; }
+  constexpr auto api() -> API { return API::Posix; }
+  constexpr auto display() -> DisplayServer { return DisplayServer::Unknown; }
 #else
   #warning "unable to detect platform"
   #define PLATFORM_UNKNOWN


### PR DESCRIPTION
Latest working Haiku build was with version 0.94 of bsnes.
This allows the latest version of the bsnes-libretro core to build and run on Haiku.