### PR TITLE
Show commit hash in core version

### DIFF
--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -593,7 +593,11 @@ unsigned retro_api_version()
 void retro_get_system_info(retro_system_info *info)
 {
 	info->library_name     = "bsnes";
-	info->library_version  = Emulator::Version;
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+	static string version(Emulator::Version, GIT_VERSION);
+	info->library_version  = version;
 	info->need_fullpath    = true;
 	info->valid_extensions = "smc|sfc|gb|gbc|bs";
 	info->block_extract = false;


### PR DESCRIPTION
This minor PR extends the `library_version` string, so that it now displays the version of the emulator itself as well as the latest commit hash, similarly to other existing libretro cores. 

This is useful especially for troubleshooting purposes, to identify which specific version people are referring to when posting issues. It is worth noting that `GIT_VERSION` already existed in the Makefile, but was not being used at all in `libretro.cpp`.

![bsnes commit hash](https://user-images.githubusercontent.com/17614150/120113970-41909800-c17d-11eb-9038-082282c944ba.png)




