### PR TITLE
Enable Indonesian, Swedish and Ukrainian localisations

### DIFF
--- a/bsnes/target-libretro/libretro.h
+++ b/bsnes/target-libretro/libretro.h
@@ -283,6 +283,9 @@ enum retro_language
    RETRO_LANGUAGE_HEBREW              = 21,
    RETRO_LANGUAGE_ASTURIAN            = 22,
    RETRO_LANGUAGE_FINNISH             = 23,
+   RETRO_LANGUAGE_INDONESIAN          = 24,
+   RETRO_LANGUAGE_SWEDISH             = 25,
+   RETRO_LANGUAGE_UKRAINIAN           = 26,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -3460,6 +3463,10 @@ struct retro_core_option_definition
     * ignored */
    const char *default_value;
 };
+
+#ifdef __PS3__
+#undef local
+#endif
 
 struct retro_core_options_intl
 {

--- a/bsnes/target-libretro/libretro_core_options.h
+++ b/bsnes/target-libretro/libretro_core_options.h
@@ -672,11 +672,14 @@ struct retro_core_options_v2 *options_intl[RETRO_LANGUAGE_LAST] = {
    &options_ar,      /* RETRO_LANGUAGE_ARABIC */
    &options_el,      /* RETRO_LANGUAGE_GREEK */
    &options_tr,      /* RETRO_LANGUAGE_TURKISH */
-   &options_sv,      /* RETRO_LANGUAGE_SLOVAK */
+   &options_sk,      /* RETRO_LANGUAGE_SLOVAK */
    &options_fa,      /* RETRO_LANGUAGE_PERSIAN */
    &options_he,      /* RETRO_LANGUAGE_HEBREW */
    &options_ast,     /* RETRO_LANGUAGE_ASTURIAN */
    &options_fi,      /* RETRO_LANGUAGE_FINNISH */
+   &options_id,      /* RETRO_LANGUAGE_INDONESIAN */
+   &options_sv,      /* RETRO_LANGUAGE_SWEDISH */
+   &options_uk,      /* RETRO_LANGUAGE_UKRAINIAN */
 };
 #endif
 


### PR DESCRIPTION
Also, fixes a _tiny_ mistake I made, resulting in Swedish being used instead of Slovak. Whoopsie.