### PR TITLE
Fix subsystems saves filename

### DIFF
--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -906,6 +906,7 @@ bool retro_load_game_special(unsigned game_type,
 			libretro_print(RETRO_LOG_INFO, "SGB ROM: %s\n", info[1].path);
 			program->gameBoy.location = info[0].path;
 			program->superFamicom.location = info[1].path;
+			program->base_name = info[0].path;
 		}
 		break;
 		case RETRO_GAME_TYPE_BSX:
@@ -914,6 +915,7 @@ bool retro_load_game_special(unsigned game_type,
 			libretro_print(RETRO_LOG_INFO, "BS-X BIOS ROM: %s\n", info[1].path);
 			program->bsMemory.location = info[0].path;
 			program->superFamicom.location = info[1].path;
+			program->base_name = info[0].path;
 		}
 		break;
 		default:


### PR DESCRIPTION
`base_name` was previously empty when using subsystems, so the core ended up creating a file called `.srm` instead of `[content_filename].srm` in the RA saves folder. This small PR fixes this.

Closes #29