### PR TITLE
libretro: Support blargg's NTSC filter

### DIFF
--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -438,6 +438,33 @@ static void update_variables(void)
 
 	}
 
+	var.key = "bsnes_video_filter";
+	var.value = NULL;
+
+	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+	{
+		if (strcmp(var.value, "None") == 0) {
+			program->filterRender = &Filter::None::render;
+			program->filterSize = &Filter::None::size;
+		}
+		else if (strcmp(var.value, "NTSC (RF)") == 0) {
+			program->filterRender = &Filter::NTSC_RF::render;
+			program->filterSize = &Filter::NTSC_RF::size;
+		}
+		else if (strcmp(var.value, "NTSC (Composite)") == 0) {
+			program->filterRender = &Filter::NTSC_Composite::render;
+			program->filterSize = &Filter::NTSC_Composite::size;
+		}
+		else if (strcmp(var.value, "NTSC (S-Video)") == 0) {
+			program->filterRender = &Filter::NTSC_SVideo::render;
+			program->filterSize = &Filter::NTSC_SVideo::size;
+		}
+		else if (strcmp(var.value, "NTSC (RGB)") == 0) {
+			program->filterRender = &Filter::NTSC_RGB::render;
+			program->filterSize = &Filter::NTSC_RGB::size;
+		}
+	}
+
 	update_option_visibility();
 }
 
@@ -838,13 +865,14 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 
 bool retro_load_game(const retro_game_info *game)
 {
-	// bsnes uses 0RGB1555 internally but it is deprecated
-	// let software conversion happen in frontend
-	/*retro_pixel_format fmt = RETRO_PIXEL_FORMAT_0RGB1555;
+	retro_pixel_format fmt = RETRO_PIXEL_FORMAT_XRGB8888;
 	if (!environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt))
-		return false;*/
+		return false;
 
 	emulator->configure("Audio/Frequency", SAMPLERATE);
+	program->filterRender = &Filter::None::render;
+	program->filterSize = &Filter::None::size;
+	program->updateVideoPalette();
 
 	update_variables();
 

--- a/bsnes/target-libretro/libretro_core_options.h
+++ b/bsnes/target-libretro/libretro_core_options.h
@@ -137,6 +137,23 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "OFF"
    },
    {
+      "bsnes_video_filter",
+      "Filter",
+      "Filter",
+      "Choose between no filtering and blargg's NTSC filter with options for RF, Composite, S-Video, or RGB",
+      NULL,
+      "video",
+      {
+         { "None", "None" },
+         { "NTSC (RF)", "NTSC (RF)" },
+         { "NTSC (Composite)", "NTSC (Composite)" },
+         { "NTSC (S-Video)", "NTSC (S-Video)" },
+         { "NTSC (RGB)", "NTSC (RGB)" },
+         { NULL, NULL },
+      },
+      "None"
+   },
+   {
       "bsnes_ppu_fast",
       "PPU (Video) - Fast Mode",
       "PPU - Fast Mode",

--- a/bsnes/target-libretro/libretro_core_options_intl.h
+++ b/bsnes/target-libretro/libretro_core_options_intl.h
@@ -77,6 +77,14 @@ extern "C" {
 #define BSNES_PPU_NO_VRAM_BLOCKING_LABEL_AR NULL
 #define BSNES_PPU_NO_VRAM_BLOCKING_LABEL_CAT_AR NULL
 #define BSNES_PPU_NO_VRAM_BLOCKING_INFO_0_AR NULL
+#define BSNES_VIDEO_FILTER_LABEL_AR NULL
+#define BSNES_VIDEO_FILTER_LABEL_CAT_AR NULL
+#define BSNES_VIDEO_FILTER_INFO_0_AR NULL
+#define OPTION_VAL_VIDEO_FILTER_NONE NULL
+#define OPTION_VAL_VIDEO_FILTER_NTSC_RF NULL
+#define OPTION_VAL_VIDEO_FILTER_NTSC_COMPOSITE NULL
+#define OPTION_VAL_VIDEO_FILTER_NTSC_SVIDEO NULL
+#define OPTION_VAL_VIDEO_FILTER_NTSC_RGB NULL
 #define BSNES_DSP_FAST_LABEL_AR NULL
 #define BSNES_DSP_FAST_LABEL_CAT_AR NULL
 #define BSNES_DSP_FAST_INFO_0_AR NULL
@@ -309,6 +317,23 @@ struct retro_core_option_v2_definition option_defs_ar[] = {
          { NULL, NULL },
       },
       "OFF"
+   },
+   {
+      "bsnes_video_filter",
+      BSNES_VIDEO_FILTER_LABEL_AR,
+      BSNES_VIDEO_FILTER_LABEL_CAT_AR,
+      BSNES_VIDEO_FILTER_INFO_0_AR,
+      NULL,
+      "video",
+      {
+         { "None", OPTION_VAL_VIDEO_FILTER_NONE  },
+         { "NTSC (RF)", OPTION_VAL_VIDEO_FILTER_NTSC_RF  },
+         { "NTSC (Composite)", OPTION_VAL_VIDEO_FILTER_NTSC_COMPOSITE  },
+         { "NTSC (S-Video)", OPTION_VAL_VIDEO_FILTER_NTSC_SVIDEO  },
+         { "NTSC (RGB)", OPTION_VAL_VIDEO_FILTER_NTSC_RGB },
+         { NULL, NULL },
+      },
+      "None"
    },
    {
       "bsnes_ppu_fast",

--- a/bsnes/target-libretro/program.h
+++ b/bsnes/target-libretro/program.h
@@ -15,14 +15,14 @@ struct Program : Emulator::Platform
 {
 	Program(Emulator::Interface * emu);
 	~Program();
-	
+
 	auto open(uint id, string name, vfs::file::mode mode, bool required) -> shared_pointer<vfs::file> override;
 	auto load(uint id, string name, string type, vector<string> options = {}) -> Emulator::Platform::Load override;
 	auto videoFrame(const uint16* data, uint pitch, uint width, uint height, uint scale) -> void override;
 	auto audioFrame(const double* samples, uint channels) -> void override;
 	auto inputPoll(uint port, uint device, uint input) -> int16 override;
 	auto inputRumble(uint port, uint device, uint input, bool enable) -> void override;
-	
+
 	auto load() -> void;
 	auto loadFile(string location) -> vector<uint8_t>;
 	auto loadSuperFamicom(string location) -> bool;
@@ -34,17 +34,18 @@ struct Program : Emulator::Platform
 	auto openRomSuperFamicom(string name, vfs::file::mode mode) -> shared_pointer<vfs::file>;
 	auto openRomGameBoy(string name, vfs::file::mode mode) -> shared_pointer<vfs::file>;
 	auto openRomBSMemory(string name, vfs::file::mode mode) -> shared_pointer<vfs::file>;
-	
+
 	auto hackPatchMemory(vector<uint8_t>& data) -> void;
-	
+	auto updateVideoPalette() -> void;
+
 	string base_name;
 
 	bool overscan = false;
 
-public:	
+public:
 	struct Game {
 		explicit operator bool() const { return (bool)location; }
-		
+
 		string option;
 		string location;
 		string manifest;
@@ -69,4 +70,11 @@ public:
 	struct BSMemory : Game {
 		vector<uint8_t> program;
 	} bsMemory;
+
+	uint32_t palette[32768];
+	uint32_t paletteDimmed[32768];
+	uint32_t videoOut[2304*2160];
+
+	Filter::Render filterRender;
+	Filter::Size filterSize;
 };


### PR DESCRIPTION
This adds support for all four of blargg's NTSC filter options to the libretro port of bsnes.

As a consequence of using the filter functionality, the pixel format has been changed to XRGB8888 (preferable to the awkward 0RGB1555 when considering cross-platform compatibility and it is seemingly deprecated anyway). It also now builds on musl-libc without patches.