### PR TITLE
Fix compilation on webOS, add to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,6 +93,12 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/tvos-arm64.yml'  
 
+  #################################### MISC ##################################
+
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -201,3 +207,10 @@ libretro-build-libnx-aarch64:
     - mv retroarch_switch.nro ../${CORENAME}_libretro_libnx.nro
     - mv retroarch_switch.elf ../${CORENAME}_libretro_libnx.elf
     - cd ../
+
+#################################### MISC ####################################
+# webOS 32-bit
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-make-default
+    - .core-defs

--- a/bsnes/gb/Core/gb.c
+++ b/bsnes/gb/Core/gb.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdlib.h>


### PR DESCRIPTION
Fails otherwise with:

```
bsnes/gb/Core/gb.c:25:5: error: implicit declaration of function ‘vasprintf’; did you mean ‘vsprintf’? [-Wimplicit-function-declaration] 25 | vasprintf(&string, fmt, args);
```