### PR TITLE
Fix for 32bit android

### DIFF
--- a/bsnes/gb/libretro/jni/Android.mk
+++ b/bsnes/gb/libretro/jni/Android.mk
@@ -17,6 +17,7 @@ endif
 
 include $(CLEAR_VARS)
 LOCAL_MODULE    := retro
+LOCAL_ARM_MODE  := arm
 LOCAL_SRC_FILES := $(SOURCES_C)
 LOCAL_CFLAGS    := -std=c99 $(COREFLAGS) $(CFLAGS)
 LOCAL_LDFLAGS   := -Wl,-version-script=$(CORE_DIR)/libretro/link.T

--- a/bsnes/target-libretro/jni/Android.mk
+++ b/bsnes/target-libretro/jni/Android.mk
@@ -52,6 +52,7 @@ SRCFILES := $(SRCDIR)/bsnes/target-libretro/libretro.cpp \
 
 include $(CLEAR_VARS)
 LOCAL_MODULE       := retro
+LOCAL_ARM_MODE     := arm
 LOCAL_SRC_FILES    := $(SRCFILES)
 LOCAL_CPPFLAGS     := -std=c++17 $(COREFLAGS)
 LOCAL_CFLAGS       := $(COREFLAGS)


### PR DESCRIPTION
Currently, the core crashes at launch on 32bit android devices.

Based on findings here [bsnes-jg be80000](https://github.com/libretro/bsnes-jg/commit/be80000a18344a521e627e6bc42230eae71a4cd9)

Fixes #50, #51, and possibly #49.