### PR TITLE
libretro: fix  error: 'is_signed' cannot be specialized

### DIFF
--- a/nall/traits.hpp
+++ b/nall/traits.hpp
@@ -39,9 +39,11 @@ namespace nall {
   using std::true_type;
 }
 
+#if !defined(__clang__) || __clang_major__ < 20
 namespace std {
   #if INTMAX_BITS >= 128
   template<> struct is_signed<int128_t> : true_type {};
   template<> struct is_unsigned<uint128_t> : true_type {};
   #endif
 }
+#endif


### PR DESCRIPTION
Fixes with ndk 29:

```
In file included from /home/cscd98/Developer/bsnes-libretro/bsnes/target-libretro/jni/../../../bsnes/target-libretro/libretro.cpp:32:
In file included from /home/cscd98/Developer/bsnes-libretro/bsnes/target-libretro/jni/../../../bsnes/target-libretro/program.cpp:1:
In file included from /home/cscd98/Developer/bsnes-libretro/bsnes/target-libretro/jni/../../../bsnes/emulator/emulator.hpp:6:
In file included from /home/cscd98/Developer/bsnes-libretro/bsnes/target-libretro/jni/../../../nall/adaptive-array.hpp:6:
/home/cscd98/Developer/bsnes-libretro/bsnes/target-libretro/jni/../../../nall/traits.hpp:44:21: error: 'is_signed' cannot be specialized: Users are not allowed to specialize this standard library entity [-Winvalid-specialization]
   44 |   template<> struct is_signed<int128_t> : true_type {};
      |                     ^
/home/cscd98/Android/Sdk/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/__type_traits/is_signed.h:26:29: note: marked 'no_specializations' here
   26 | struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_signed : _BoolConstant<__is_signed(_Tp)> {};
      |                             ^
/home/cscd98/Android/Sdk/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/__config:1177:9: note: expanded from macro '_LIBCPP_NO_SPECIALIZATIONS'
 1177 |       [[_Clang::__no_specializations__("Users are not allowed to specialize this standard library entity")]]
```